### PR TITLE
Fixed the link to docker docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ following:
 
 ### Docker container
 
-Find [here](doc/docker.md) information on running Etherpad in a container.
+Find [here](doc/docker.adoc) information on running Etherpad in a container.
 
 ## Plugins
 


### PR DESCRIPTION
The docs have been migrated from markdown asciidoc , but README.md is still referring to  `docker.md` instead of `docker.adoc`. This has been fixed.

<!--

1. If you haven't already, please read https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#pull-requests .
2. Run all the tests, both front-end and back-end.  (see https://github.com/ether/etherpad-lite/blob/master/CONTRIBUTING.md#testing)
3. Keep business logic and validation on the server-side.
4. Update documentation.
5. Write `fixes #XXXX` in your comment to auto-close an issue.

If you're making a big change, please explain what problem it solves:
- Explain the purpose of the change.  When adding a way to do X, explain why it is important to be able to do X.
- Show the current vs desired behavior with screenshots/GIFs.

-->
